### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ This file contains the list of changes made to pyjoulescope.
 
 ## 0.4.6
 
-2019 Jul ??
+2019 Jul 15
 
 *   Added optional application-specific metadata to datafile collection start.
 *   Added support for voltage range to datafile: save/load/process correctly.
 *   Improved missing sample (NaN) handling robustness.
 *   Modified Driver.statistics_callback to match statistics_get format.
 *   Compute total charge in addition to energy.
+*   Fixed stream_buffer int/uint comparison warning.
 
 
 ## 0.4.5

--- a/joulescope/stream_buffer.pyx
+++ b/joulescope/stream_buffer.pyx
@@ -954,7 +954,7 @@ cdef class StreamBuffer:
         cdef int64_t idx_start
         cdef int64_t end_gap
         cdef int64_t start_orig = start
-        cdef int n
+        cdef uint64_t n
         cdef np.ndarray[np.float32_t, ndim=2, mode = 'c'] out_c
 
         if stop + self.length < (<int64_t> self.processed_sample_id):


### PR DESCRIPTION
It is nice to call out the supported Python versions in `setup.py` using `python_requires`, even though this is well documented in the README and the setup.py fails straightaway in Python <=3.5 because of the Python 3.6+ string formatting syntax.