### PR TITLE
only catch Exception when scanning

### DIFF
--- a/joulescope/driver.py
+++ b/joulescope/driver.py
@@ -1334,7 +1334,7 @@ def scan(name: str = None, config=None) -> List[Device]:
         else:
             devices = [Device(d, config=config) for d in devices]
         return devices
-    except:
+    except Exception:
         log.exception('while scanning for devices')
         return []
 


### PR DESCRIPTION
Fixes #20 

Not 100% certain if there's other exceptions that need to be accounted for here, but RuntimeError is the only one that seemed relevant.