### PR TITLE
Fixed DownsamplingStreamBuffer to use reductions correctly #26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 This file contains the list of changes made to pyjoulescope.
 
 
+## 0.9.12
+
+2022 May 31 [in progress]
+
+* Fixed DownsamplingStreamBuffer to use reductions correctly #26
+
+
 ## 0.9.11
 
 2022 Feb 22

--- a/joulescope/downsampling_stream_buffer.pxi
+++ b/joulescope/downsampling_stream_buffer.pxi
@@ -15,7 +15,6 @@
 
 from .decimators import DECIMATORS
 from .filter_fir cimport FilterFir, filter_fir_cbk
-STREAM_BUFFER_REDUCTIONS = [200, 100, 50]  # in samples in sample units of the previous reduction
 STREAM_BUFFER_DURATION = 1.0  # seconds
 
 
@@ -60,7 +59,7 @@ cdef class DownsamplingStreamBuffer:
         self._output_sampling_frequency = output_sampling_frequency
         self._downsample_m = input_sampling_frequency / self._output_sampling_frequency
         if input_sampling_frequency:
-            self._stream_buffer = StreamBuffer(STREAM_BUFFER_DURATION, STREAM_BUFFER_REDUCTIONS, input_sampling_frequency)
+            self._stream_buffer = StreamBuffer(STREAM_BUFFER_DURATION, reductions, input_sampling_frequency)
             self._stream_buffer.process_stats_callback_set(<stream_buffer_process_fn> self._stream_buffer_process_cbk, <void *> self)
         reduction_step = int(np.prod(reductions))
         length = int(duration * output_sampling_frequency)

--- a/joulescope/version.py
+++ b/joulescope/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.11"
+__version__ = "0.9.12"
 
 __title__ = "joulescope"
 __description__ = 'Joulescope™ host driver and utilities'


### PR DESCRIPTION
The implementation was using a hard-coded STREAM_BUFFER_REDUCTIONS
rather than the value provided.