### PR TITLE
explicitly specify libusb version for Linux set up instructions

### DIFF
--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -50,7 +50,7 @@ Linux
 Use your package manager to install python.  On Debian-based systems, including
 Ubuntu, use apt::
 
-    $ sudo apt install python3-dev python3-pip libusb-1.0
+    $ sudo apt install python3-dev python3-pip libusb-1.0-0
     $ python3 -VV
     
 The user must have sufficient permissions to access Joulescopes.


### PR DESCRIPTION
if one tries to install libusb as specified currently the following error is generated-
```
E: Unable to locate package libusb-1.0
E: Couldn't find any package by glob 'libusb-1.0'
```

Instead if you specify `libusb-1.0-0`, it works fine.

Tested on Raspberry Pi 5 running-
```
Distributor ID:	Debian
Description:	Debian GNU/Linux 12 (bookworm)
Release:	12
Codename:	bookworm
```
